### PR TITLE
Update GitHub Actions > AWS + OIDC sample

### DIFF
--- a/all/github-actions-oidc/aws/steampipe-sample-aws-workflow.yml
+++ b/all/github-actions-oidc/aws/steampipe-sample-aws-workflow.yml
@@ -7,7 +7,6 @@ on:
     - cron: "0 4 7,14,21,28 * *"
 
 # These permissions are needed to interact with GitHub's OIDC Token endpoint.
-
 permissions:
   id-token: write # This is required for requesting the JWT
   contents: write # This is required for actions/checkout
@@ -29,7 +28,8 @@ jobs:
           role-session-name: "steampipe-demo"
           role-duration-seconds: 900
           aws-region: "us-east-1"
-          # Steampipe benchmark runs against this region unless a connection is specified in aws.spc file. More details at https://hub.steampipe.io/plugins/turbot/aws#credentials-from-environment-variables
+          # Steampipe benchmark runs against this region unless a connection is specified in aws.spc file. 
+          # More details at https://hub.steampipe.io/plugins/turbot/aws#credentials-from-environment-variables
 
       - name: "Install Steampipe cli and plugin"
         id: steampipe-installation
@@ -44,6 +44,7 @@ jobs:
 
       - name: "Run Steampipe benchmark"
         id: steampipe-benchmark
+        continue-on-error: true
         run: |
 
           # Install the Steampipe AWS Compliance mod
@@ -51,7 +52,7 @@ jobs:
           cd .steampipe/mods/github.com/turbot/steampipe-mod-aws-compliance*
 
           # Run the AWS CIS v1.5.0 benchmark
-          steampipe check benchmark.cis_v150 --export=${GITHUB_WORKSPACE}/steampipe/benchmarks/aws/cis_v150_"$(date +"%d_%B_%Y")".html --output=none
+          steampipe check benchmark.cis_v150 --export=$GITHUB_WORKSPACE/steampipe/benchmarks/aws/cis_v150_"$(date +"%d_%B_%Y")".html --output=none
 
       - name: "Commit the file to github"
         id: push-to-gh


### PR DESCRIPTION
The GitHub action may abruptly exit when there are alarms/errors in the Benchmark. This is due to a non-zero exit code (1 or 2) when the benchmarks has alarms/errors. Listed the Steampipe exit codes below for reference. 

```
const (
	ExitCodeSuccessful                 = 0
	ExitCodeControlsAlarm              = 1   // check - no runtime errors, 1 or more control alarms, no control errors
	ExitCodeControlsError              = 2   // check - no runtime errors, 1 or more control errors
	ExitCodePluginLoadingError         = 11  // plugin - loading error
	ExitCodePluginListFailure          = 12  // plugin - listing failed
	ExitCodePluginNotFound             = 13  // plugin - not found
	ExitCodeSnapshotCreationFailed     = 21  // snapshot - creation failed
	ExitCodeSnapshotUploadFailed       = 22  // snapshot - upload failed
	ExitCodeServiceSetupFailure        = 31  // service - setup failed
	ExitCodeServiceStartupFailure      = 32  // service - start failed
	ExitCodeServiceStopFailure         = 33  // service - stop failed
	ExitCodeQueryExecutionFailed       = 41  // query - 1 or more queries failed - change in behavior(previously the exitCode used to be the number of queries that failed)
	ExitCodeLoginCloudConnectionFailed = 51  // login - connecting to cloud failed
	ExitCodeInitializationFailed       = 250 // common - initialization failed
	ExitCodeBindPortUnavailable        = 251 // common (service/dashboard) - port binding failed
	ExitCodeNoModFile                  = 252 // common - no mod file
	ExitCodeFileSystemAccessFailure    = 253 // common - file system access failed
	ExitCodeInsufficientOrWrongInputs  = 254 // common - runtime error (insufficient or wrong input)
	ExitCodeUnknownErrorPanic          = 255 // common - runtime error (unknown panic)
)
```