### PR TITLE
Added ECS task role authentication option to cross-account setup script

### DIFF
--- a/all/aws-organizations-scripts/generate_config_for_cross_account_roles.sh
+++ b/all/aws-organizations-scripts/generate_config_for_cross_account_roles.sh
@@ -39,7 +39,7 @@ if ( [ $COMMAND == "IMDS" ] || [ $COMMAND == "ECS" ] ) && [ -z $AWS_CONFIG_FILE 
   usage
 fi
 
-if [ $COMMAND == "LOCAL" ] && [ -z $SOURCE_PROFILE ] ; then
+if [ -z $SOURCE_PROFILE ] ; then
   echo "ERROR: Source profile not defined"
   usage
 fi

--- a/all/aws-organizations-scripts/generate_config_for_cross_account_roles.sh
+++ b/all/aws-organizations-scripts/generate_config_for_cross_account_roles.sh
@@ -40,8 +40,12 @@ if ( [ $COMMAND == "IMDS" ] || [ $COMMAND == "ECS" ] ) && [ -z $AWS_CONFIG_FILE 
 fi
 
 if [ -z $SOURCE_PROFILE ] ; then
-  echo "ERROR: Source profile not defined"
-  usage
+  if [ $COMMAND == "LOCAL" ] ; then
+    echo "ERROR: Source profile not defined"
+    usage
+  else
+    SOURCE_PROFILE="default"
+  fi
 fi
 
 # STEAMPIPE_INSTALL_DIR overrides the default steampipe directory of ~/.steampipe

--- a/all/aws-organizations-scripts/generate_config_for_cross_account_roles.sh
+++ b/all/aws-organizations-scripts/generate_config_for_cross_account_roles.sh
@@ -20,7 +20,7 @@ AWS_CONFIG_FILE=$3
 SOURCE_PROFILE=$4
 
 usage () {
-  echo "Usage: $0 [IMDS | LOCAL ] <AUDITROLE> <AWS_CONFIG_FILE> <SOURCE_PROFILE>"
+  echo "Usage: $0 [IMDS | ECS | LOCAL ] <AUDITROLE> <AWS_CONFIG_FILE> <SOURCE_PROFILE>"
   exit 1
 }
 
@@ -29,12 +29,12 @@ if [ -z "$COMMAND" ] ; then
   usage
 fi
 
-if [ $COMMAND != "IMDS" ] && [ $COMMAND != "LOCAL" ] ; then
+if [ $COMMAND != "IMDS" ] && [ $COMMAND != "ECS" ] && [ $COMMAND != "LOCAL" ] ; then
   echo "ERROR: Invalid Command: $COMMAND"
   usage
 fi
 
-if [ $COMMAND == "IMDS" ] && [ -z $AWS_CONFIG_FILE ] ; then
+if ( [ $COMMAND == "IMDS" ] || [ $COMMAND == "ECS" ] ) && [ -z $AWS_CONFIG_FILE ] ; then
   echo "ERROR: AWS config file not defined"
   usage
 fi
@@ -67,7 +67,7 @@ echo "Creating Steampipe Connections in $SP_CONFIG_FILE and AWS Profiles in $AWS
 echo "# Automatically Generated at `date`" > $SP_CONFIG_FILE
 echo "# Steampipe profiles, Automatically Generated at `date`" > $AWS_CONFIG_FILE
 
-if [ $COMMAND == "IMDS" ] ; then
+if [ $COMMAND == "IMDS" ] || [ $COMMAND == "ECS" ] ; then
 # Your AWS Config file needs a [default] section
 cat <<EOF>>$AWS_CONFIG_FILE
 [default]
@@ -110,6 +110,16 @@ cat <<EOF>>$AWS_CONFIG_FILE
 [profile sp_${ACCOUNT_NAME}]
 role_arn = arn:aws:iam::${ACCOUNT_ID}:role/${AUDITROLE}
 credential_source = Ec2InstanceMetadata
+role_session_name = steampipe
+EOF
+
+elif [ $COMMAND == "ECS" ] ; then
+# Append an entry to the AWS Creds file
+cat <<EOF>>$AWS_CONFIG_FILE
+
+[profile sp_${ACCOUNT_NAME}]
+role_arn = arn:aws:iam::${ACCOUNT_ID}:role/${AUDITROLE}
+credential_source = EcsContainer
 role_session_name = steampipe
 EOF
 


### PR DESCRIPTION
We are running Steampipe on a scheduled ECS Fargate task to run cross-account queries. For that the `IMDS` authentication method doesn't work. Instead, we attach a task role to the task and we need to specify `EcsContainer` in the config entries. 

I'll also provide an update to the docs (Edit: this is the docs PR https://github.com/turbot/steampipe-docs/pull/142). Feel free to adjust as needed. I'll also publish a blog post about getting all this to run soon™.