### PR TITLE
Update AWS OIDC Thumbprint in GitHub Actions

### DIFF
--- a/all/github-actions-oidc/aws/main.tf
+++ b/all/github-actions-oidc/aws/main.tf
@@ -7,7 +7,7 @@ resource "aws_iam_openid_connect_provider" "github_actions" {
     "sts.amazonaws.com",
   ]
 
-  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1", "1c58a3a8518e8759bf075b76b750d4f2df264fcd"]
   # NOTE: If Github changes/renews the GitHub Actions SSL certificates then the thumbprint may change. 
   # More details at, https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html
 


### PR DESCRIPTION
https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws/

Hello,

We are sending this notification because you have configured a GitHub OpenID Connect (OIDC) identity provider (IdP) in your AWS account. GitHub uses a cross-signed TLS server certificate for GitHub’s OIDC servers which can have two intermediate certificates. Each of these intermediate certificates has a unique thumbprint. If you configured the GitHub IdP in your account using only one thumbprint, you may have encountered “Error: OpenIDConnect provider's HTTPS certificate doesn't match configured thumbprint” when attempting to access AWS resources using GitHub as the identity provider. This would occur when the certificate thumbprint configured in AWS does not match the one presented by the GitHub server.

No action is required from you.

Starting July 6, 2023, AWS began securing communication with GitHub’s OIDC identity provider (IdP) using our library of trusted root Certificate Authorities instead of using a certificate thumbprint to verify the IdP’s server certificate. This approach ensures that your GitHub OIDC configuration behaves correctly without disruption during future certificate rotations and changes. With this new validation approach in place, your legacy thumbprint(s) will remain in your configuration but will no longer be needed for validation purposes.

For additional assistance, please contact AWS Support [1].

[1] https://aws.amazon.com/support

Sincerely,
Amazon Web Services