### PR TITLE
Don't include suspended accounts when generating AWS config

### DIFF
--- a/all/aws-organizations-scripts/generate_config_for_cross_account_roles.sh
+++ b/all/aws-organizations-scripts/generate_config_for_cross_account_roles.sh
@@ -149,7 +149,7 @@ connection "aws_${SP_NAME}" {
 
 EOF
 
-done < <(aws organizations list-accounts --query Accounts[].[Name,Id,Status] --output text --profile $SOURCE_PROFILE)
+done < <(aws organizations list-accounts --query "Accounts[?Status!='SUSPENDED'].[Name,Id,Status]" --output text --profile $SOURCE_PROFILE)
 
 if [ $COMMAND == "LOCAL" ] ; then
   echo "Now append $AWS_CONFIG_FILE to your active config file where $SOURCE_PROFILE is defined"


### PR DESCRIPTION
Currently if an organization has any suspended accounts these will be added to the config.  This results in errors as API requests will always fail against suspended accounts.