### PR TITLE
Lowercase connection names

### DIFF
--- a/all/aws-organizations-scripts/generate_config_for_cross_account_roles.sh
+++ b/all/aws-organizations-scripts/generate_config_for_cross_account_roles.sh
@@ -101,6 +101,9 @@ while read line ; do
   # Steampipe doesn't like dashes, so we need to swap for underscores
   SP_NAME=`echo $ACCOUNT_NAME | sed s/-/_/g`
 
+  # Steampipe doesn't like uppercase letters, so we need to lowercase the account name
+  SP_NAME=`echo $SP_NAME | tr '[:upper:]' '[:lower:]'`
+
 if [ $ACCOUNT_NAME == "$SOURCE_PROFILE" ] ; then
   # TODO: improve how the source profile is checked
   echo "Skipping $ACCOUNT_NAME as it is the source profile"


### PR DESCRIPTION
I get these errors when connections have uppercase letters in them when trying to query them directly:

```
Error: relation "myConnection.table" does not exist (SQLSTATE 42P01)
```

This change will lowercase all connection names.