### PR TITLE
Improvements on AWS SSO utility tool

### DIFF
--- a/all/aws-organizations-scripts/generate_config_for_sso.sh
+++ b/all/aws-organizations-scripts/generate_config_for_sso.sh
@@ -15,26 +15,52 @@
 #
 #
 # Usage:
-# ./generate_config_for_sso.sh <SSO_PREFIX> <SSO_ROLE> <STEAMPIPE_CONFIG> <AWS_CONFIG>
+# ./generate_config_for_sso.sh <SSO_PREFIX> <SSO_ROLE> <STEAMPIPE_CONFIG> <AWS_CONFIG> [AWS_SSO_SESSION_NAME]
 #
 # Example:
-# ./generate_config_for_sso.sh fooli security-audit ~/.steampipe/config/aws.spc ~/.aws/fooli-config
+# ./generate_config_for_sso.sh fooli "AdministratorAccess,Billing,DataScientist" ~/.steampipe/config/aws.spc ~/.aws/fooli-config
+#
+# Or with a session name and a specific role:
+# ./generate_config_for_sso.sh fooli security-audit ~/.steampipe/config/aws.spc ~/.aws/fooli-config "my-session-name"
+#
+# A session name is useful when you have multiple accounts, and with a single session login you authenticate to all accounts in that session.
 #
 # Note: You can specify where both the AWS and Steampipe config files will be written
 
+set -e
 
 SSO_PREFIX=$1
-SSO_ROLE=$2
+SSO_ROLES=(${2//,/ })
 STEAMPIPE_CONFIG=$3
 AWS_CONFIG=$4
+AWS_SSO_SESSION_NAME=$5
 
-if [ -z "$AWS_CONFIG" ] ; then
-  echo "Missing SSO Prefix"
-  echo "Usage: $0 <SSO_PREFIX> <SSO_ROLE> <STEAMPIPE_CONFIG> <AWS_CONFIG>"
+print_usage() {
+    echo "USAGE:"
+    echo "  $0 <SSO_PREFIX> <SSO_ROLE> <STEAMPIPE_CONFIG> <AWS_CONFIG> [AWS_SSO_SESSION_NAME]"
+    echo ""
+    echo "EXAMPLES:"
+    echo "  $0 fooli \"AdministratorAccess,Billing,DataScientist\" ~/.steampipe/config/aws.spc ~/.aws/fooli-config"
+    echo "  $0 fooli security-audit ~/.steampipe/config/aws.spc ~/.aws/fooli-config \"my-session-name\""
+    echo ""
+    echo "ARGUMENTS:"
+    echo "  - SSO_PREFIX: The prefix for your AWS SSO URL. For example, if your SSO URL is https://fooli.awsapps.com, the prefix is 'fooli'."
+    echo "  - SSO_ROLE: A comma-separated list of AWS SSO roles you want to generate profiles for. If you have access to 'AdministratorAccess in 2 account and 'Billing' in 4 accounts, you would specify 'AdministratorAccess,Billing'. The first role in the list will be used to determine which accounts to generate profiles for, so the order matters. If none of the accounts have the specified roles, the account will be skipped."
+    echo "  - STEAMPIPE_CONFIG: The path to the Steampipe config file to write the profiles to. This file will be overwritten if it already exists."
+    echo "  - AWS_CONFIG: The path to the AWS config file to write the profiles to. This file will be overwritten if it already exists."
+}
+
+if [[ $# -lt 4 ]]; then
+  print_usage
+  echo ""
+  echo "ERROR: Missing $((4 - $#)) required argument(s)."
   exit 1
 fi
 
 START_URL="https://${SSO_PREFIX}.awsapps.com/start"
+AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-us-east-1}"
+
+echo "Starting SSO login for $START_URL in region $AWS_DEFAULT_REGION"
 
 aws sso-oidc register-client --client-name 'profiletool' --client-type 'public' --region "${AWS_DEFAULT_REGION}" > client.json
 
@@ -66,7 +92,18 @@ auth_url=`cat device_auth.json | jq -r .verificationUriComplete`
 devicecode=`cat device_auth.json | jq -r .deviceCode`
 rm device_auth.json
 
-open $auth_url
+# Handle WSL
+if [ -e /mnt/c/Windows/System32/cmd.exe ] ; then
+  if command -v wslview > /dev/null ; then
+    wslview $auth_url
+  else
+    # Not all WSL installations have wslview, so we'll use cmd.exe
+    # this will display a warning abouth the command prompt, but it's the best we can do
+    /mnt/c/Windows/System32/cmd.exe /c start $auth_url
+  fi
+else
+  open $auth_url
+fi
 
 echo "$auth_url was opened in your browser. Please click allow."
 echo "Press Enter when complete"
@@ -98,19 +135,32 @@ connection "aws" {
 
 EOF
 
+# Set IFS to newline to handle account names with spaces
+IFS=$'\n'
 
-for a in `aws sso list-accounts --access-token "$token" --region "${AWS_DEFAULT_REGION}" --output text | awk '{print $2":"$3}'` ; do
+for a in `aws sso list-accounts --access-token "$token" --region "${AWS_DEFAULT_REGION}" --output json | jq -r '.accountList[] | .accountId + ":" + .accountName'`; do
 
   acctnum=`echo $a | awk -F: '{print $1}'`
-  acctname=`echo $a | awk -F: '{print $2}'`
+  acctname=`echo $a | awk -F: '{print $2}' | sed s/\ /_/g` # Replace spaces with underscores
 
   # Steampipe doesn't like dashes, so we need to swap for underscores
   SP_NAME=`echo $acctname | sed s/-/_/g`
 
-  aws sso list-account-roles --account-id "$acctnum" --access-token "$token" --region "${AWS_DEFAULT_REGION}" | grep $SSO_ROLE > /dev/null
-  if [ $? -ne 0 ] ; then
-    echo "# $SSO_ROLE was not in list of SSO roles available to this user. Skipping account $acctname ($acctnum) \n"
+  available_roles=`aws sso list-account-roles --account-id "$acctnum" --access-token "$token" --region "${AWS_DEFAULT_REGION}" --output json | jq -r '.roleList[].roleName'`
+  acctrole=""
+  for role in ${available_roles[@]}; do
+    if [[ ${SSO_ROLES[@]} =~ ${role} ]]; then
+      acctrole=$role
+      break
+    fi
+  done
+
+  if [ -z "$acctrole" ]; then
+    echo "WARNING: Skipping account $acctname ($acctnum) because it did not match any of the specified roles"
   else
+      echo "Adding account $acctname ($acctnum) with role $acctrole"
+      if [ -z "$AWS_SSO_SESSION_NAME" ]; then
+        # Use traditional SSO method if session is not set
 
 cat << EOF>> $AWS_CONFIG
 
@@ -118,10 +168,22 @@ cat << EOF>> $AWS_CONFIG
 sso_start_url = ${START_URL}
 sso_region = ${AWS_DEFAULT_REGION}
 sso_account_id = ${acctnum}
-sso_role_name = ${SSO_ROLE}
+sso_role_name = ${acctrole}
 EOF
 
-# And append an entry to the Steampipe config file
+      else
+        # Use SSO session if set
+cat << EOF>> $AWS_CONFIG
+
+[profile ${acctname}]
+sso_session = ${AWS_SSO_SESSION_NAME}
+sso_account_id = ${acctnum}
+sso_role_name = ${acctrole}
+EOF
+
+      fi
+
+    # And append an entry to the Steampipe config file
 cat <<EOF>>$STEAMPIPE_CONFIG
 connection "aws_${SP_NAME}" {
   plugin  = "aws"
@@ -132,8 +194,5 @@ connection "aws_${SP_NAME}" {
 EOF
 
   fi
-
-
-
 done
 


### PR DESCRIPTION
I've added some features to improve usability of the script, and also fixed some scenarios that the script wouldn't work:

- **Add**: Improve usage instructions to be more descriptive
- **Add**: Support multiple roles, as in large organizations accounts are likely having more than a single access role
- **Add**: Support for AWS CLI session, this way it's possible to authenticate only once for all the profiles in the same session
- **Fix**: Not all (at least mine didn't have) shells have the variable `AWS_DEFAULT_REGION` set, so I've added the default value of `us-east-1`
- **Add**: Support for execution from within a WSL environment
- **Fix**: Accounts with spaces in the name weren't supported, I've made some changes in order to accept those as those are valid names