### PR TITLE
New Parameter Regions for aws-organizations-scripts/generate_config_for_cross_account_roles.sh

### DIFF
--- a/all/aws-organizations-scripts/README.md
+++ b/all/aws-organizations-scripts/README.md
@@ -12,12 +12,13 @@ Please refer to the [documentation on steampipe.io](https://steampipe.io/docs/gu
 
 * **[generate_config_for_cross_account_roles.sh](https://github.com/turbot/steampipe-samples/tree/main/all/aws-organizations-scripts/generate_config_for_cross_account_roles.sh)**\
   This script can be used to generate the aws config file and steampipe aws.spc files for a single AWS Organization. Usage is:
-  `./generate_config_for_cross_account_roles.sh [IMDS | LOCAL ] <AUDIT_ROLE> <AWS_CONFIG_FILE> <SOURCE_PROFILE>`, where:
+  `./generate_config_for_cross_account_roles.sh [IMDS | LOCAL ] <AUDIT_ROLE> <AWS_CONFIG_FILE> <SOURCE_PROFILE> <REGIONS>`, where:
     * `IMDS` if you're running in EC2.
     * `LOCAL` if you're running from the local machine.
     * `AUDIT_ROLE` is the name fo the [cross-account role](https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html) created in all accounts.
     * `AWS_CONFIG_FILE` is where the script will output the AWS SDK profiles
     * `SOURCE_PROFILE` is only required when `LOCAL` is specified. It is the profile with the local credentials used to perform the [AssumeRole](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html) on the cross-account role.
+    * `REGIONS` is only required if you need to limit your queries to specific regions (e.g. due to having the region deny control enabled in Control Tower). Format: `'["us-east-1", "eu-central-1"]'`. Defaults to `'["*"]'`.
 
 * **[generate_config_for_multipayer.py](https://github.com/turbot/steampipe-samples/tree/main/all/aws-organizations-scripts/generate_config_for_multipayer.py)**\
   This script takes a list of AWS Management Accounts, and uses the specified `--rolename` to AssumeRole into the management account, list the child accounts, and build an AWS Config File and aws.spc file. Usage is:

--- a/all/aws-organizations-scripts/generate_config_for_cross_account_roles.sh
+++ b/all/aws-organizations-scripts/generate_config_for_cross_account_roles.sh
@@ -19,9 +19,10 @@ COMMAND=$1
 AUDIT_ROLE=$2
 AWS_CONFIG_FILE=$3
 SOURCE_PROFILE=$4
+REGIONS=$5
 
 usage () {
-  echo "Usage: $0 [IMDS | ECS | LOCAL ] <AUDIT_ROLE> <AWS_CONFIG_FILE> <SOURCE_PROFILE>"
+  echo "Usage: $0 [IMDS | ECS | LOCAL ] <AUDIT_ROLE> <AWS_CONFIG_FILE> <SOURCE_PROFILE> <REGIONS>"
   exit 1
 }
 
@@ -49,6 +50,16 @@ if [ -z $SOURCE_PROFILE ] ; then
   fi
 fi
 
+# If regions are not provided, default to all regions
+if [ -z "$REGIONS" ]; then
+  echo "No regions specified, using all regions."
+  ENABLED_REGIONS='["*"]'
+else
+  echo "Regions specified: $REGIONS"
+  ENABLED_REGIONS=$REGIONS
+fi
+
+
 # STEAMPIPE_INSTALL_DIR overrides the default steampipe directory of ~/.steampipe
 if [ -z $STEAMPIPE_INSTALL_DIR ] ; then
   echo "STEAMPIPE_INSTALL_DIR not defined, using the default location"
@@ -66,7 +77,6 @@ if [ -f $AWS_CONFIG_FILE ] ; then
 fi
 
 SP_CONFIG_FILE=${STEAMPIPE_INSTALL_DIR}/config/aws.spc
-ALL_REGIONS='["*"]'
 
 echo "Generating AWS profiles in $AWS_CONFIG_FILE"
 echo "# Steampipe profiles, automatically generated at `date`" > $AWS_CONFIG_FILE
@@ -147,7 +157,7 @@ cat <<EOF>>$SP_CONFIG_FILE
 connection "aws_${SP_NAME}" {
   plugin  = "aws"
   profile = "sp_${ACCOUNT_NAME}"
-  regions = ${ALL_REGIONS}
+  regions = ${ENABLED_REGIONS}
 }
 
 EOF


### PR DESCRIPTION
**Problem:**
I realized that the script is currently unusable for us, as we actively block most regions except for 3. When using the config generated by the script, I receive a lot of AccessDenied Errors, which come from API calls being made to blocked regions.

**Solution**
I added a new parameter that overwrites the default of ["*"] if it is specified. 

**Test**
I tested it locally and on EC2 and ensured that the change is backwards compatibly for anyone currently using the script.
