### PR TITLE
Harden GitHub Actions: set explicit permissions

### DIFF
--- a/.github/workflows/hn.yml
+++ b/.github/workflows/hn.yml
@@ -8,6 +8,9 @@ defaults:
    branches:
 #     - main
 
+permissions:
+  contents: read
+
 jobs:
   cron:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Harden GitHub Actions workflows

- Pin all action/workflow references to immutable commit SHAs
- Add explicit minimal `permissions` blocks

**Why**: Prevents supply chain attacks where a tag could be moved to point to malicious code. Explicit permissions reduce blast radius if a workflow is compromised.