### PR TITLE
Fix workflow permissions: contents: write needed for git push

### DIFF
--- a/.github/workflows/hn.yml
+++ b/.github/workflows/hn.yml
@@ -9,7 +9,7 @@ defaults:
 #     - main
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   cron:


### PR DESCRIPTION
## Summary
- Change `contents: read` to `contents: write` in workflow-level permissions block
- The `hn.yml` workflow uses `git push origin main` which requires write access to repository contents

## Test plan
- [ ] Verify the workflow can successfully `git push` HN data updates